### PR TITLE
setup.py, testcase, travis and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,124 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+pypesq/cypesq.c
+
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - pip install -e .
   - pip install coverage
   - pip install numpy
-  - pip install soundfile
+  - pip install scipy
 
 script:
   - pytest tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 
 language: python
 python:
-  - 3.5
   - 3.6
   - 3.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ python:
   - 3.6
   - 3.7
 
-cache: pip
-
 install:
+  - pip install cython
   - pip install -e .
   - pip install coverage
   - pip install numpy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+
+language: python
+python:
+  - 3.5
+  - 3.6
+  - 3.7
+
+cache: pip
+
+install:
+  - pip install -e .
+  - pip install coverage
+  - pip install numpy
+  - pip install soundfile
+
+script:
+  - pytest tests/
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # python-pesq
-.. image:: https://travis-ci.org/boeddeker/python-pesq.svg?branch=master
-    :target: https://travis-ci.org/boeddeker/python-pesq
-    :alt: Travis Status
+
+[![Build Status](https://travis-ci.org/boeddeker/python-pesq.svg?branch=master)](https://travis-ci.org/boeddeker/python-pesq)
 
 PESQ (Perceptual Evaluation of Speech Quality) Wrapper for Python Users
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ This code is designed for numpy array specially.
 # Build and Install
 ```bash
 $ git clone https://github.com/ludlows/python-pesq.git
-$ cd python-pesq/pypesq
-$ python setup.py build_ext --inplace
-$ cd ..
+$ cd python-pesq
+$ pip install .
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ $ cd python-pesq
 $ pip install .
 ```
 
+# Install with pip
+```
+$ pip install https://github.com/ludlows/python-pesq/archive/master.zip
+```
 
 # Example for narrow band and wide band
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # python-pesq
+.. image:: https://travis-ci.org/boeddeker/python-pesq.svg?branch=master
+    :target: https://travis-ci.org/boeddeker/python-pesq
+    :alt: Travis Status
 
 PESQ (Perceptual Evaluation of Speech Quality) Wrapper for Python Users
 

--- a/setup.py
+++ b/setup.py
@@ -3,21 +3,27 @@
 # Python Wrapper for PESQ Score (narrow band and wide band)
 import numpy
 
+from setuptools import find_packages
 from distutils.core import setup
 from distutils.extension import Extension
+
 from Cython.Build import cythonize, build_ext
 
 extensions = [
     Extension(
         "cypesq",
-        ["cypesq.pyx", "dsp.c", "pesqdsp.c","pesqmod.c"],
+        ["pypesq/cypesq.pyx", "pypesq/dsp.c", "pypesq/pesqdsp.c","pypesq/pesqmod.c"],
         include_dirs=[numpy.get_include()],
         language="c")
 ]
 setup(
-    name="PESQ Python Wrapper",
-    cmdclass = {'build_ext': build_ext},
+    name="pypesq",
+    packages=find_packages(),
+    # cmdclass = {'build_ext': build_ext},
+    ext_package='pypesq',
     ext_modules=cythonize(extensions),
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest', 'soundfile'],
 )
 
 

--- a/tests/test_pesq.py
+++ b/tests/test_pesq.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-import soundfile
+import scipy.io.wavfile
 
 from pypesq import pypesq
 
@@ -10,8 +10,8 @@ def test():
     ref_path = data_dir / 'speech.wav'
     deg_path = data_dir / 'speech_bab_0dB.wav'
 
-    ref, sample_rate = soundfile.read(ref_path)
-    deg, sample_rate = soundfile.read(deg_path)
+    sample_rate, ref = scipy.io.wavfile.read(ref_path)
+    sample_rate, deg = scipy.io.wavfile.read(deg_path)
 
     score = pypesq(ref=ref, deg=deg, fs=sample_rate, mode='wb')
 

--- a/tests/test_pesq.py
+++ b/tests/test_pesq.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import soundfile
+
+from pypesq import pypesq
+
+
+def test():
+    data_dir = Path(__file__).parent.parent / 'audio'
+    ref_path = data_dir / 'speech.wav'
+    deg_path = data_dir / 'speech_bab_0dB.wav'
+
+    ref, sample_rate = soundfile.read(ref_path)
+    deg, sample_rate = soundfile.read(deg_path)
+
+    score = pypesq(ref=ref, deg=deg, fs=sample_rate, mode='wb')
+
+    assert score == 1.0832337141036987, score
+
+    score = pypesq(ref=ref, deg=deg, fs=sample_rate, mode='nb')
+
+    assert score == 1.6072081327438354, score


### PR DESCRIPTION
This PR is a suggestion.

It is common to have the setup.py in the root directory of the git.
I moved the setup.py to the root directory.

In the readme is mentioned, how the code can be tested.
I added a testcase for that example and added a travis file, so travis can test the code.

I also added a badge from travis to indicate if the build is successful.
When you plan to merge this, it is recommended, that you create a travis acc and activate travis for this repo. Then you can change the badge link to your travis acc.