### PR TITLE
Improved error handling [PR#16 to dev]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vIM buffer files
+*.swp
+*.swo

--- a/pesq/__init__.py
+++ b/pesq/__init__.py
@@ -3,20 +3,16 @@
 # Python Wrapper for PESQ Score (narrow band and wide band)
 
 import numpy as np
-from .cypesq import cypesq, cypesq_retvals, cypesq_last_error_message
+from .cypesq import cypesq, cypesq_retvals, cypesq_error_message as pesq_error_message
 from .cypesq import PesqError, InvalidSampleRateError, OutOfMemoryError
 from .cypesq import BufferTooShortError, NoUtterancesError
-
-class PesqOnError:
-    RAISE_EXCEPTION = 0
-    RETURN_VALUES   = 1
 
 USAGE = """
        Run model on reference ref and degraded deg
        Sample rate (fs) - No default. Must select either 8000 or 16000.
        Note there is narrow band (nb) mode only when sampling rate is 8000Hz.
        """
-def pesq(fs, ref, deg, mode, on_error=PesqOnError.RAISE_EXCEPTION):
+def pesq(fs, ref, deg, mode, on_error=PesqError.RAISE_EXCEPTION):
     """
     Args:
         ref: numpy 1D array, reference audio signal 
@@ -45,7 +41,7 @@ def pesq(fs, ref, deg, mode, on_error=PesqOnError.RAISE_EXCEPTION):
     else:
         mode_code = 0
     
-    if on_error == PesqOnError.RETURN_VALUES:
+    if on_error == PesqError.RETURN_VALUES:
         return cypesq_retvals(
             fs,
             (ref/maxval).astype(np.float32),
@@ -59,6 +55,3 @@ def pesq(fs, ref, deg, mode, on_error=PesqOnError.RAISE_EXCEPTION):
             (deg/maxval).astype(np.float32),
             mode_code
         )
-
-def pesq_last_error_message():
-    return cypesq_last_error_message()

--- a/pesq/__init__.py
+++ b/pesq/__init__.py
@@ -3,14 +3,18 @@
 # Python Wrapper for PESQ Score (narrow band and wide band)
 
 import numpy as np
-from .cypesq import cypesq
+from .cypesq import cypesq, cypesq_retvals, cypesq_last_error_message
+
+class PesqOnError:
+    RAISE_EXCEPTION = 0
+    RETURN_VALUES   = 1
 
 USAGE = """
        Run model on reference ref and degraded deg
        Sample rate (fs) - No default. Must select either 8000 or 16000.
        Note there is narrow band (nb) mode only when sampling rate is 8000Hz.
        """
-def pesq(fs, ref, deg, mode):
+def pesq(fs, ref, deg, mode, on_error=PesqOnError.RAISE_EXCEPTION):
     """
     Args:
         ref: numpy 1D array, reference audio signal 
@@ -23,14 +27,36 @@ def pesq(fs, ref, deg, mode):
     if mode != 'wb' and mode != 'nb':
         print(USAGE)
         raise ValueError("mode should be either 'nb' or 'wb'")
+
     if fs != 8000 and fs != 16000:
         print(USAGE)
         raise ValueError("fs (sampling frequency) should be either 8000 or 16000")
+
     if fs == 8000 and mode == 'wb':
         print(USAGE)
         raise ValueError("no wide band mode if fs = 8000")
-    maxval = max(np.max(np.abs(ref/1.0)), np.max(np.abs(deg/1.0)))
-    if mode == 'wb':
-        return cypesq(fs, (ref/maxval).astype(np.float32), (deg/maxval).astype(np.float32), 1)
-    return cypesq(fs, (ref/maxval).astype(np.float32), (deg/maxval).astype(np.float32), 0)
 
+    maxval = max(np.max(np.abs(ref/1.0)), np.max(np.abs(deg/1.0)))
+
+    if mode == 'wb':
+        mode_code = 1
+    else:
+        mode_code = 0
+    
+    if on_error == PesqOnError.RETURN_VALUES:
+        return cypesq_retvals(
+            fs,
+            (ref/maxval).astype(np.float32),
+            (deg/maxval).astype(np.float32),
+            mode_code
+        )
+    else:
+        return cypesq(
+            fs,
+            (ref/maxval).astype(np.float32),
+            (deg/maxval).astype(np.float32),
+            mode_code
+        )
+
+def pesq_last_error_message():
+    return cypesq_last_error_message()

--- a/pesq/__init__.py
+++ b/pesq/__init__.py
@@ -4,6 +4,8 @@
 
 import numpy as np
 from .cypesq import cypesq, cypesq_retvals, cypesq_last_error_message
+from .cypesq import PesqError, InvalidSampleRateError, OutOfMemoryError
+from .cypesq import BufferTooShortError, NoUtterancesError
 
 class PesqOnError:
     RAISE_EXCEPTION = 0

--- a/pesq/pesq.h
+++ b/pesq/pesq.h
@@ -234,6 +234,12 @@ extern long Align_Nfft_16k;
 #ifndef PESQ_H
 #define PESQ_H
 
+#define PESQ_ERROR_UNKNOWN                -1
+#define PESQ_ERROR_INVALID_SAMPLE_RATE    -2 
+#define PESQ_ERROR_OUT_OF_MEMORY          -3
+#define PESQ_ERROR_BUFFER_TOO_SHORT       -4
+#define PESQ_ERROR_NO_UTTERANCES_DETECTED -5
+
 typedef struct {
   char  path_name[512];
   char  file_name [128];
@@ -320,8 +326,9 @@ void split_align( SIGNAL_INFO * ref_info, SIGNAL_INFO * deg_info,
      long * Best_ED2, long * Best_D2, float * Best_DC2,
      long * Best_BP );
 void pesq_psychoacoustic_model(
-SIGNAL_INFO * ref_info, SIGNAL_INFO * deg_info,
-ERROR_INFO * err_info, float * ftmp);
+    SIGNAL_INFO * ref_info, SIGNAL_INFO * deg_info,
+    ERROR_INFO * err_info, long * Error_Flag, char ** Error_Type,
+    float * ftmp);
 void apply_pesq( float * x_data, float * ref_surf,
 float * y_data, float * deg_surf, long NVAD_windows, float * ftmp,
 ERROR_INFO * err_info );
@@ -359,5 +366,6 @@ ERROR_INFO * err_info );
 #ifndef A_WEIGHT 
 #define     A_WEIGHT    0.0309
 #endif
+
 /* END OF FILE */
 

--- a/pesq/pesq.h
+++ b/pesq/pesq.h
@@ -234,11 +234,14 @@ extern long Align_Nfft_16k;
 #ifndef PESQ_H
 #define PESQ_H
 
+#define PESQ_ERROR_SUCCESS                 0
 #define PESQ_ERROR_UNKNOWN                -1
 #define PESQ_ERROR_INVALID_SAMPLE_RATE    -2 
-#define PESQ_ERROR_OUT_OF_MEMORY          -3
-#define PESQ_ERROR_BUFFER_TOO_SHORT       -4
-#define PESQ_ERROR_NO_UTTERANCES_DETECTED -5
+#define PESQ_ERROR_OUT_OF_MEMORY_REF      -3
+#define PESQ_ERROR_OUT_OF_MEMORY_DEG      -4
+#define PESQ_ERROR_OUT_OF_MEMORY_TMP      -5
+#define PESQ_ERROR_BUFFER_TOO_SHORT       -6
+#define PESQ_ERROR_NO_UTTERANCES_DETECTED -7
 
 typedef struct {
   char  path_name[512];

--- a/pesq/pesqmain.h
+++ b/pesq/pesqmain.h
@@ -257,7 +257,7 @@ float WB_InIIR_Hsos_8k[LINIIR] = {
 long WB_InIIR_Nsos_16k = 1L;
 float WB_InIIR_Hsos_16k[LINIIR] = {
     2.740826f,  -5.4816519f,  2.740826f,  -1.9444777f,  0.94597794f };
-       
+
 void pesq_measure (SIGNAL_INFO * ref_info, SIGNAL_INFO * deg_info,
     ERROR_INFO * err_info, long * Error_Flag, char ** Error_Type)
 {
@@ -271,168 +271,175 @@ void pesq_measure (SIGNAL_INFO * ref_info, SIGNAL_INFO * deg_info,
     deg_info-> VAD = NULL;
     deg_info-> logVAD = NULL;
         
-    if ((*Error_Flag) == 0){
-//         printf ("Reading reference file %s...", ref_info-> path_name);
-
-       load_src (Error_Flag, Error_Type, ref_info);
-    //    if ((*Error_Flag) == 0){}
-        //    printf ("done.\n");
+    // If Error_Flag was already set to something different than zero,
+    // Report unknown error. In practice shouldn't happen, as the function that
+    // calls this function returns if its Error_Flag wasn't zero.
+    if (*Error_Flag != 0) {
+        *Error_Flag = PESQ_ERROR_UNKNOWN;
+        // We're rewriting the flag, but keeping the Error_Type for later
+        return;
     }
-    if ((*Error_Flag) == 0)
+
+    // Load Reference Buffer
+    load_src(Error_Flag, Error_Type, ref_info);
+    if (*Error_Flag != 0) {
+        *Error_Flag = PESQ_ERROR_OUT_OF_MEMORY;
+        return;
+    }
+
+    // Load Degraded Buffer
+    load_src(Error_Flag, Error_Type, deg_info);
+    if (*Error_Flag != 0) {
+        *Error_Flag = PESQ_ERROR_OUT_OF_MEMORY;
+        return;
+    }
+
+    // If one of the buffers has less than 1/4 of a second, return error.
+    if ((ref_info-> Nsamples - 2 * SEARCHBUFFER * Downsample < Fs / 4) ||
+        (deg_info-> Nsamples - 2 * SEARCHBUFFER * Downsample < Fs / 4))
     {
-//         printf ("Reading degraded file %s...", deg_info-> path_name);
-
-       load_src (Error_Flag, Error_Type, deg_info);
-    //    if ((*Error_Flag) == 0){}
-        //    printf ("done.\n");
+        *Error_Flag = PESQ_ERROR_BUFFER_TOO_SHORT;
+        *Error_Type = "Reference or Degraded below 1/4 second - processing stopped ";
+        return;
     }
 
-    if (((ref_info-> Nsamples - 2 * SEARCHBUFFER * Downsample < Fs / 4) ||
-         (deg_info-> Nsamples - 2 * SEARCHBUFFER * Downsample < Fs / 4)) &&
-        ((*Error_Flag) == 0))
-    {
-        (*Error_Flag) = 2;
-        (*Error_Type) = "Reference or Degraded below 1/4 second - processing stopped ";
+    // Allocate temporary storage
+    alloc_other(ref_info, deg_info, Error_Flag, Error_Type, &ftmp);
+    if (*Error_Flag != 0) {
+        *Error_Flag = PESQ_ERROR_OUT_OF_MEMORY;
+        return;
     }
 
-    if ((*Error_Flag) == 0)
-    {
-        alloc_other (ref_info, deg_info, Error_Flag, Error_Type, &ftmp);
+    int     maxNsamples = max (ref_info-> Nsamples, deg_info-> Nsamples);
+    float * model_ref; 
+    float * model_deg; 
+    long    i;
+    // FILE *resultsFile;
+
+    // printf (" Level normalization...\n");            
+    fix_power_level (ref_info, "reference", maxNsamples);
+    fix_power_level (deg_info, "degraded", maxNsamples);
+
+    // printf (" IRS filtering...\n"); 
+    if( Fs == 16000 ) {
+        WB_InIIR_Nsos = WB_InIIR_Nsos_16k;
+        WB_InIIR_Hsos = WB_InIIR_Hsos_16k;
+    } else {
+        WB_InIIR_Nsos = WB_InIIR_Nsos_8k;
+        WB_InIIR_Hsos = WB_InIIR_Hsos_8k;
+    }
+    if( ref_info->input_filter == 1 ) {
+        apply_filter (ref_info-> data, ref_info-> Nsamples, 26, standard_IRS_filter_dB);
+    } else {
+        for( i = 0; i < 16; i++ ) {
+            ref_info->data[SEARCHBUFFER * Downsample + i - 1]
+                *= (float)i / 16.0f;
+            ref_info->data[ref_info->Nsamples - SEARCHBUFFER * Downsample - i]
+                *= (float)i / 16.0f;
+        }
+        IIRFilt( WB_InIIR_Hsos, WB_InIIR_Nsos, NULL,
+             ref_info->data + SEARCHBUFFER * Downsample,
+             ref_info->Nsamples - 2 * SEARCHBUFFER * Downsample, NULL );
+    }
+    if( deg_info->input_filter == 1 ) {
+        apply_filter (deg_info-> data, deg_info-> Nsamples, 26, standard_IRS_filter_dB);
+    } else {
+        for( i = 0; i < 16; i++ ) {
+            deg_info->data[SEARCHBUFFER * Downsample + i - 1]
+                *= (float)i / 16.0f;
+            deg_info->data[deg_info->Nsamples - SEARCHBUFFER * Downsample - i]
+                *= (float)i / 16.0f;
+        }
+        IIRFilt( WB_InIIR_Hsos, WB_InIIR_Nsos, NULL,
+             deg_info->data + SEARCHBUFFER * Downsample,
+             deg_info->Nsamples - 2 * SEARCHBUFFER * Downsample, NULL );
     }
 
-    if ((*Error_Flag) == 0)
-    {   
-        int     maxNsamples = max (ref_info-> Nsamples, deg_info-> Nsamples);
-        float * model_ref; 
-        float * model_deg; 
-        long    i;
-        // FILE *resultsFile;
+    model_ref = (float *) safe_malloc ((ref_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000)) * sizeof (float));
+    model_deg = (float *) safe_malloc ((deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000)) * sizeof (float));
 
-        // printf (" Level normalization...\n");            
-        fix_power_level (ref_info, "reference", maxNsamples);
-        fix_power_level (deg_info, "degraded", maxNsamples);
+    for (i = 0; i < ref_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
+        model_ref [i] = ref_info-> data [i];
+    }
 
-        // printf (" IRS filtering...\n"); 
-        if( Fs == 16000 ) {
-            WB_InIIR_Nsos = WB_InIIR_Nsos_16k;
-            WB_InIIR_Hsos = WB_InIIR_Hsos_16k;
-        } else {
-            WB_InIIR_Nsos = WB_InIIR_Nsos_8k;
-            WB_InIIR_Hsos = WB_InIIR_Hsos_8k;
-        }
-        if( ref_info->input_filter == 1 ) {
-            apply_filter (ref_info-> data, ref_info-> Nsamples, 26, standard_IRS_filter_dB);
-        } else {
-            for( i = 0; i < 16; i++ ) {
-                ref_info->data[SEARCHBUFFER * Downsample + i - 1]
-                    *= (float)i / 16.0f;
-                ref_info->data[ref_info->Nsamples - SEARCHBUFFER * Downsample - i]
-                    *= (float)i / 16.0f;
-            }
-            IIRFilt( WB_InIIR_Hsos, WB_InIIR_Nsos, NULL,
-                 ref_info->data + SEARCHBUFFER * Downsample,
-                 ref_info->Nsamples - 2 * SEARCHBUFFER * Downsample, NULL );
-        }
-        if( deg_info->input_filter == 1 ) {
-            apply_filter (deg_info-> data, deg_info-> Nsamples, 26, standard_IRS_filter_dB);
-        } else {
-            for( i = 0; i < 16; i++ ) {
-                deg_info->data[SEARCHBUFFER * Downsample + i - 1]
-                    *= (float)i / 16.0f;
-                deg_info->data[deg_info->Nsamples - SEARCHBUFFER * Downsample - i]
-                    *= (float)i / 16.0f;
-            }
-            IIRFilt( WB_InIIR_Hsos, WB_InIIR_Nsos, NULL,
-                 deg_info->data + SEARCHBUFFER * Downsample,
-                 deg_info->Nsamples - 2 * SEARCHBUFFER * Downsample, NULL );
-        }
+    for (i = 0; i < deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
+        model_deg [i] = deg_info-> data [i];
+    }
 
-        model_ref = (float *) safe_malloc ((ref_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000)) * sizeof (float));
-        model_deg = (float *) safe_malloc ((deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000)) * sizeof (float));
+    input_filter( ref_info, deg_info, ftmp );
 
+    // printf (" Variable delay compensation...\n");            
+    calc_VAD (ref_info);
+    calc_VAD (deg_info);
+    
+    crude_align (ref_info, deg_info, err_info, WHOLE_SIGNAL, ftmp);
+
+    utterance_locate (ref_info, deg_info, err_info, ftmp);
+
+    for (i = 0; i < ref_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
+        ref_info-> data [i] = model_ref [i];
+    }
+
+    for (i = 0; i < deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
+        deg_info-> data [i] = model_deg [i];
+    }
+
+    safe_free (model_ref);
+    safe_free (model_deg); 
+
+    if (ref_info-> Nsamples < deg_info-> Nsamples) {
+        float *new_ref = (float *) safe_malloc((deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000)) * sizeof(float));
+        long  i;
         for (i = 0; i < ref_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
-            model_ref [i] = ref_info-> data [i];
+            new_ref [i] = ref_info-> data [i];
         }
-    
-        for (i = 0; i < deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
-            model_deg [i] = deg_info-> data [i];
+        for (i = ref_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); 
+             i < deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
+            new_ref [i] = 0.0f;
         }
-    
-        input_filter( ref_info, deg_info, ftmp );
-
-        // printf (" Variable delay compensation...\n");            
-        calc_VAD (ref_info);
-        calc_VAD (deg_info);
-        
-        crude_align (ref_info, deg_info, err_info, WHOLE_SIGNAL, ftmp);
-
-        utterance_locate (ref_info, deg_info, err_info, ftmp);
-    
-        for (i = 0; i < ref_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
-            ref_info-> data [i] = model_ref [i];
-        }
-    
-        for (i = 0; i < deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
-            deg_info-> data [i] = model_deg [i];
-        }
-
-        safe_free (model_ref);
-        safe_free (model_deg); 
-    
-        if ((*Error_Flag) == 0) {
-            if (ref_info-> Nsamples < deg_info-> Nsamples) {
-                float *new_ref = (float *) safe_malloc((deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000)) * sizeof(float));
-                long  i;
-                for (i = 0; i < ref_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
-                    new_ref [i] = ref_info-> data [i];
-                }
-                for (i = ref_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); 
-                     i < deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
-                    new_ref [i] = 0.0f;
-                }
-                safe_free (ref_info-> data);
-                ref_info-> data = new_ref;
-                new_ref = NULL;
-            } else {
-                if (ref_info-> Nsamples > deg_info-> Nsamples) {
-                    float *new_deg = (float *) safe_malloc((ref_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000)) * sizeof(float));
-                    long  i;
-                    for (i = 0; i < deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
-                        new_deg [i] = deg_info-> data [i];
-                    }
-                    for (i = deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); 
-                         i < ref_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
-                        new_deg [i] = 0.0f;
-                    }
-                    safe_free (deg_info-> data);
-                    deg_info-> data = new_deg;
-                    new_deg = NULL;
-                }
-            }
-        }        
-
-        // printf (" Acoustic model processing...\n");    
-        pesq_psychoacoustic_model (ref_info, deg_info, err_info, ftmp);
-    
         safe_free (ref_info-> data);
-        safe_free (ref_info-> VAD);
-        safe_free (ref_info-> logVAD);
-        safe_free (deg_info-> data);
-        safe_free (deg_info-> VAD);
-        safe_free (deg_info-> logVAD);
-        safe_free (ftmp);
+        ref_info-> data = new_ref;
+        new_ref = NULL;
+    } else {
+        if (ref_info-> Nsamples > deg_info-> Nsamples) {
+            float *new_deg = (float *) safe_malloc((ref_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000)) * sizeof(float));
+            long  i;
+            for (i = 0; i < deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
+                new_deg [i] = deg_info-> data [i];
+            }
+            for (i = deg_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); 
+                 i < ref_info-> Nsamples + DATAPADDING_MSECS  * (Fs / 1000); i++) {
+                new_deg [i] = 0.0f;
+            }
+            safe_free (deg_info-> data);
+            deg_info-> data = new_deg;
+            new_deg = NULL;
+        }
+    }
 
-		if ( err_info->mode == NB_MODE ) // narrow band 
-		{   
-			// printf("narrow\n");
-            err_info->mapped_mos = 0.999f+4.0f/(1.0f+(float)exp((-1.4945f*err_info->pesq_mos+4.6607f)));
-		}
-        else // wide band
-		{   
-            // printf("wide\n");
-			err_info->mapped_mos = 0.999f+4.0f/(1.0f+(float)exp((-1.3669f*err_info->pesq_mos+3.8224f)));
-			err_info->pesq_mos = -1.0;
-		}
+    pesq_psychoacoustic_model(ref_info, deg_info, err_info, Error_Flag, Error_Type, ftmp);
+    // We're not checking Error_Flag and returning here as we still need to do 
+    // some clean-up before returning.
+
+    safe_free (ref_info-> data);
+    safe_free (ref_info-> VAD);
+    safe_free (ref_info-> logVAD);
+    safe_free (deg_info-> data);
+    safe_free (deg_info-> VAD);
+    safe_free (deg_info-> logVAD);
+    safe_free (ftmp);
+
+    if ( err_info->mode == NB_MODE ) // narrow band 
+    {   
+        // printf("narrow\n");
+        err_info->mapped_mos = 0.999f+4.0f/(1.0f+(float)exp((-1.4945f*err_info->pesq_mos+4.6607f)));
+    }
+    else // wide band
+    {   
+        // printf("wide\n");
+        err_info->mapped_mos = 0.999f+4.0f/(1.0f+(float)exp((-1.3669f*err_info->pesq_mos+3.8224f)));
+        err_info->pesq_mos = -1.0;
+    }
 
 //         resultsFile = fopen (ITU_RESULTS_FILE, "at");
 // 
@@ -472,9 +479,6 @@ void pesq_measure (SIGNAL_INFO * ref_info, SIGNAL_INFO * deg_info,
 // 
 //            fclose (resultsFile);
 //         }
-
-    }
-
 }
 
 /* END OF FILE */

--- a/tests/test_pesq.py
+++ b/tests/test_pesq.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 import pytest
 import numpy as np
 import scipy.io.wavfile

--- a/tests/test_pesq.py
+++ b/tests/test_pesq.py
@@ -1,9 +1,12 @@
-from pathlib import Path
+#!/usr/bin/python3
 
+import pytest
+import numpy as np
 import scipy.io.wavfile
 
-from pesq import pesq
+from pathlib import Path
 
+from pesq import pesq, NoUtterancesError, PesqError
 
 def test():
     data_dir = Path(__file__).parent.parent / 'audio'
@@ -20,3 +23,30 @@ def test():
     score = pesq(ref=ref, deg=deg, fs=sample_rate, mode='nb')
 
     assert score == 1.6072081327438354, score
+
+def test_no_utterances_nb_mode():
+    SAMPLE_RATE = 8000
+    silent_ref = np.zeros(SAMPLE_RATE)
+    deg        = np.random.randn(SAMPLE_RATE)
+
+    with pytest.raises(NoUtterancesError) as e:
+        pesq(ref=silent_ref, deg=deg, fs=SAMPLE_RATE, mode='nb')
+
+    score = pesq(ref=silent_ref, deg=deg, fs=SAMPLE_RATE, mode='nb',
+        on_error=PesqError.RETURN_VALUES)
+
+    assert score == PesqError.NO_UTTERANCES_DETECTED, score
+
+def test_no_utterances_wb_mode():
+    SAMPLE_RATE = 16000
+    silent_ref = np.zeros(SAMPLE_RATE)
+    deg        = np.random.randn(SAMPLE_RATE)
+
+    with pytest.raises(NoUtterancesError) as e:
+        pesq(ref=silent_ref, deg=deg, fs=SAMPLE_RATE, mode='wb')
+
+    score = pesq(ref=silent_ref, deg=deg, fs=SAMPLE_RATE, mode='wb',
+        on_error=PesqError.RETURN_VALUES)
+
+    assert score == PesqError.NO_UTTERANCES_DETECTED, score
+


### PR DESCRIPTION
Same contents of  #16.

- pypesq now has an on_error parameter that decides the behaviour of the function on error
- cypesq will now call cypesq_retvals and raise an exception if the returned value is negative
- cypesq_retvals will not crash-and-burn if no utterances are detected in the buffer
- pesq_measure will now return early and override the Error_Flag with its own values instead of exposing internal Error_Flags
- pow_of exit(1)'s were changed to asserts
- Adding vIM buffer files to .gitignore